### PR TITLE
Migration on RDF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,58 +2,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>at.ac.univie.mminf</groupId>
   <artifactId>qSKOS</artifactId>
-  <version>1.3.1</version>
+  <version>2.0.0</version>
   <name>qSKOS</name>
   <dependencies>
       <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-repository-sail</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-sail-nativerdf</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-sail-memory</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-queryparser-sparql</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-rdfxml</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-turtle</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-n3</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-ntriples</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-trix</artifactId>
-          <version>${sesame.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.openrdf.sesame</groupId>
-          <artifactId>sesame-rio-trig</artifactId>
-          <version>${sesame.version}</version>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-runtime</artifactId>
+          <version>${rdf4j.version}</version>
       </dependency>
   	<dependency>
   		<groupId>junit</groupId>
@@ -70,9 +25,16 @@
   	<dependency>
   		<groupId>org.apache.httpcomponents</groupId>
   		<artifactId>httpclient</artifactId>
-  		<version>4.1.2</version>
+  		<!-- Use the same version as in the RDF4J dependency to avoid conflict in the onejar -->
+  		<version>4.5.2</version>
   		<type>jar</type>
   		<scope>compile</scope>
+  		<exclusions>
+  			<exclusion>
+	  			<groupId>commons-logging</groupId>
+	  			<artifactId>commons-logging</artifactId>
+  			</exclusion>
+  		</exclusions>
   	</dependency>
 
     <dependency>
@@ -91,21 +53,21 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-compiler-plugin</artifactId>
-			<version>2.3.2</version>
+			<version>3.6.1</version>
             <configuration>
-                <source>1.7</source>
-                <target>1.7</target>
+                <source>1.8</source>
+                <target>1.8</target>
             </configuration>
 		</plugin>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-source-plugin</artifactId>
-			<version>2.1.2</version>
+			<version>3.0.1</version>
 		</plugin>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-jar-plugin</artifactId>
-			<version>2.4</version>
+			<version>3.0.2</version>
 			<configuration>
 				<archive>
 					<manifest>
@@ -117,7 +79,7 @@
 			</configuration>
 		</plugin>
 		<plugin>
-			<groupId>org.dstovall</groupId>
+			<groupId>com.jolira</groupId>
 			<artifactId>onejar-maven-plugin</artifactId>
 			<version>1.4.4</version>
 			<configuration>
@@ -135,7 +97,7 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
-			<version>2.8.1</version>
+			<version>2.10.4</version>
         	<configuration>
 				<show>public</show>
 			</configuration>
@@ -143,23 +105,8 @@
 	</plugins>
   </build>
 
-  <pluginRepositories>
-	<pluginRepository>
-		<id>onejar-maven-plugin.googlecode.com</id>
-		<url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
-	</pluginRepository>
-  </pluginRepositories>
-
-  <repositories>
-    <repository>
-        <id>openrdf</id>
-        <name>openrdf repository</name>
-        <url>http://repo.aduna-software.org/maven2/releases</url>
-    </repository>
-  </repositories>
-
   <properties>
-    <sesame.version>2.7.9</sesame.version>
+    <rdf4j.version>2.2.1</rdf4j.version>
   </properties>
 
 </project>

--- a/src/main/java/at/ac/univie/mminf/qskos4j/QSkos.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/QSkos.java
@@ -36,9 +36,9 @@ import at.ac.univie.mminf.qskos4j.issues.skosintegrity.UndefinedSkosResources;
 import at.ac.univie.mminf.qskos4j.progress.IProgressMonitor;
 import at.ac.univie.mminf.qskos4j.progress.StubProgressMonitor;
 import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
-import org.openrdf.OpenRDFException;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,7 +71,7 @@ public class QSkos {
 
     private List<Issue> registeredIssues = new ArrayList<Issue>();
 
-    public QSkos(File file) throws OpenRDFException, IOException {
+    public QSkos(File file) throws RDF4JException, IOException {
         this();
 
         RepositoryBuilder repositoryBuilder = new RepositoryBuilder();
@@ -245,7 +245,7 @@ public class QSkos {
         this.baseURI = baseURI;
     }
 
-    public void addSparqlEndPoint(String endpointUrl) throws OpenRDFException {
+    public void addSparqlEndPoint(String endpointUrl) throws RDF4JException {
         missingInLinks.addSparqlEndPoint(endpointUrl);
     }
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/cmd/ReportCollector.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/cmd/ReportCollector.java
@@ -2,8 +2,8 @@ package at.ac.univie.mminf.qskos4j.cmd;
 
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +29,7 @@ class ReportCollector {
     }
 
     void outputIssuesReport(boolean shouldWriteGraphs)
-        throws IOException, OpenRDFException
+        throws IOException, RDF4JException
     {
         File reportFile = createReportFile();
         BufferedWriter reportWriter = new BufferedWriter(new FileWriter(reportFile));
@@ -59,7 +59,7 @@ class ReportCollector {
         reportWriter.write(reportSummary);
     }
 
-    private void processIssues() throws OpenRDFException {
+    private void processIssues() throws RDF4JException {
         int issueNumber = 0;
         Iterator<Issue> issueIt = issues.iterator();
         while (issueIt.hasNext()) {
@@ -74,7 +74,7 @@ class ReportCollector {
         logger.info("Report complete!");
     }
 
-    private String createReportSummary() throws IOException, OpenRDFException {
+    private String createReportSummary() throws IOException, RDF4JException {
         StringBuffer summary = new StringBuffer();
         summary.append("* Summary of Quality Issue Occurrences:\n");
 
@@ -86,7 +86,7 @@ class ReportCollector {
         return summary.toString();
     }
 
-    private String prepareOccurrenceText(Issue issue) throws OpenRDFException {
+    private String prepareOccurrenceText(Issue issue) throws RDF4JException {
         String occurrenceText = "";
         if (issue.getResult().isProblematic()) {
             occurrenceText = "FAIL";
@@ -108,7 +108,7 @@ class ReportCollector {
     private void writeReportBody(BufferedWriter reportWriter,
                                  File reportFile,
                                  boolean shouldWriteGraphs)
-        throws IOException, OpenRDFException
+        throws IOException, RDF4JException
     {
         reportWriter.write("* Detailed coverage of each Quality Issue:\n\n");
         Iterator<Issue> issueIt = issues.iterator();
@@ -134,7 +134,7 @@ class ReportCollector {
     }
 
     private void writeTextReport(Issue issue, BufferedWriter writer)
-        throws IOException, OpenRDFException
+        throws IOException, RDF4JException
     {
         writer.write(createIssueHeader(issue));
         writer.newLine();
@@ -163,7 +163,7 @@ class ReportCollector {
         return absolutePath.substring(0, absolutePath.lastIndexOf(File.separator));
     }
 
-    private void writeGraphFiles(Issue issue, String dotFilesPath) throws IOException, OpenRDFException {
+    private void writeGraphFiles(Issue issue, String dotFilesPath) throws IOException, RDF4JException {
         BufferedWriter graphFileWriter = new BufferedWriter(new FileWriter(dotFilesPath + issue.getId() + ".dot"));
         issue.getResult().generateReport(graphFileWriter, Result.ReportFormat.DOT);
         graphFileWriter.close();

--- a/src/main/java/at/ac/univie/mminf/qskos4j/cmd/VocEvaluate.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/cmd/VocEvaluate.java
@@ -10,8 +10,8 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
-import org.openrdf.OpenRDFException;
-import org.openrdf.repository.Repository;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.repository.Repository;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,12 +94,12 @@ public class VocEvaluate {
 		catch (IOException ioException) {
 			System.err.println("!! Error reading file: " +ioException.getMessage());
 		}
-		catch (OpenRDFException rdfException) {
+		catch (RDF4JException rdfException) {
 			System.err.println("!! Error processing vocabulary: " +rdfException.getMessage());
 		} 
 	}
 		
-	public VocEvaluate(String[] args) throws OpenRDFException, IOException
+	public VocEvaluate(String[] args) throws RDF4JException, IOException
 	{
         qskos = new QSkos();
         parseCmdParams(args);
@@ -146,7 +146,7 @@ public class VocEvaluate {
 		}
 	}
 		
-	private void listIssuesOrEvaluate() throws OpenRDFException, IOException
+	private void listIssuesOrEvaluate() throws RDF4JException, IOException
 	{
 		if (parsedCommand.vocabFilenames == null) {
 			if (parsedCommand instanceof CommandAnalyze) {
@@ -186,7 +186,7 @@ public class VocEvaluate {
         }
 	}
 	
-	private void evaluate() throws OpenRDFException, IOException
+	private void evaluate() throws RDF4JException, IOException
 	{
 		setup();
 
@@ -197,7 +197,7 @@ public class VocEvaluate {
         reportCollector.outputIssuesReport(shouldWriteGraphs());
 	}
 	
-	private void setup() throws OpenRDFException, IOException {
+	private void setup() throws RDF4JException, IOException {
         setupLogging();
 
         RepositoryBuilder repositoryBuilder = new RepositoryBuilder();

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/HierarchyGraphBuilder.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/HierarchyGraphBuilder.java
@@ -4,14 +4,14 @@ import at.ac.univie.mminf.qskos4j.util.graph.NamedEdge;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.graph.DefaultDirectedGraph;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public class HierarchyGraphBuilder {
 	private DirectedGraph<Resource, NamedEdge> graph;
     private RepositoryConnection repCon;
 
-	public DirectedGraph<Resource, NamedEdge> createGraph() throws OpenRDFException
+	public DirectedGraph<Resource, NamedEdge> createGraph() throws RDF4JException
 	{
         logger.debug("Creating hierarchy graph");
         graph = new DefaultDirectedGraph<Resource, NamedEdge>(NamedEdge.class);
@@ -33,7 +33,7 @@ public class HierarchyGraphBuilder {
         return graph;
 	}
 	
-	private TupleQueryResult findTriples(String skosHierarchyProperty) throws OpenRDFException
+	private TupleQueryResult findTriples(String skosHierarchyProperty) throws RDF4JException
 	{
 		    String query = createHierarchicalGraphQuery(skosHierarchyProperty);
             return repCon.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate();

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/Issue.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/Issue.java
@@ -3,9 +3,9 @@ package at.ac.univie.mminf.qskos4j.issues;
 import at.ac.univie.mminf.qskos4j.progress.IProgressMonitor;
 import at.ac.univie.mminf.qskos4j.progress.StubProgressMonitor;
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 public abstract class Issue<T extends Result<?>> {
 
@@ -47,9 +47,9 @@ public abstract class Issue<T extends Result<?>> {
         this.weblink = weblink;
     }
 
-    protected abstract T invoke() throws OpenRDFException;
+    protected abstract T invoke() throws RDF4JException;
 
-    public final T getResult() throws OpenRDFException {
+    public final T getResult() throws RDF4JException {
         if (result == null) {
             result = invoke();
         }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/clusters/ClustersResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/clusters/ClustersResult.java
@@ -4,7 +4,7 @@ import at.ac.univie.mminf.qskos4j.result.ResourceCollectionsResult;
 import at.ac.univie.mminf.qskos4j.util.graph.GraphExporter;
 import at.ac.univie.mminf.qskos4j.util.graph.NamedEdge;
 import org.jgrapht.DirectedGraph;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/clusters/DisconnectedConceptClusters.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/clusters/DisconnectedConceptClusters.java
@@ -8,15 +8,15 @@ import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.alg.ConnectivityInspector;
 import org.jgrapht.graph.DirectedMultigraph;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQuery;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +51,7 @@ public class DisconnectedConceptClusters extends Issue<ClustersResult> {
     }
 
     @Override
-    protected ClustersResult invoke() throws OpenRDFException {
+    protected ClustersResult invoke() throws RDF4JException {
         createGraph();
 
         Collection<Collection<Resource>> connectedSets = new ArrayList<Collection<Resource>>();
@@ -60,7 +60,7 @@ public class DisconnectedConceptClusters extends Issue<ClustersResult> {
         return new ClustersResult(connectedSets, graph);
     }
 
-    private void createGraph() throws OpenRDFException
+    private void createGraph() throws RDF4JException
     {
         graph = new DirectedMultigraph<Resource, NamedEdge>(NamedEdge.class);
 
@@ -96,7 +96,7 @@ public class DisconnectedConceptClusters extends Issue<ClustersResult> {
                 }
             }
         }
-        catch (OpenRDFException e) {
+        catch (RDF4JException e) {
             logger.error("Error finding relations of concept '" +concept+ "'");
         }
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/AuthoritativeConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/AuthoritativeConcepts.java
@@ -3,8 +3,8 @@ package at.ac.univie.mminf.qskos4j.issues.concepts;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +37,12 @@ public class AuthoritativeConcepts extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         getAuthResourceIdentifier();
         return new CollectionResult<Resource>(extractAuthoritativeConceptsFromInvolved());
     }
 
-    private void determineAuthResourceIdentifier() throws OpenRDFException {
+    private void determineAuthResourceIdentifier() throws RDF4JException {
         try {
             extractAuthResourceIdentifierFromBaseURI();
         }
@@ -55,7 +55,7 @@ public class AuthoritativeConcepts extends Issue<CollectionResult<Resource>> {
         authResourceIdentifier = new java.net.URI(baseURI).getHost();
     }
 
-    private void guessAuthoritativeResourceIdentifier() throws OpenRDFException {
+    private void guessAuthoritativeResourceIdentifier() throws RDF4JException {
         HostNameOccurrencies hostNameOccurencies = new HostNameOccurrencies();
 
         Iterator<Resource> resourcesListIt = new MonitoredIterator<Resource>(
@@ -77,7 +77,7 @@ public class AuthoritativeConcepts extends Issue<CollectionResult<Resource>> {
         logger.info("Guessed authoritative resource identifier: '" +authResourceIdentifier+ "'");
     }
 
-    private Collection<Resource> extractAuthoritativeConceptsFromInvolved() throws OpenRDFException
+    private Collection<Resource> extractAuthoritativeConceptsFromInvolved() throws RDF4JException
     {
         Collection<Resource> authoritativeConcepts = new HashSet<Resource>();
 
@@ -98,7 +98,7 @@ public class AuthoritativeConcepts extends Issue<CollectionResult<Resource>> {
         reset();
     }
 
-    public String getAuthResourceIdentifier() throws OpenRDFException {
+    public String getAuthResourceIdentifier() throws RDF4JException {
         if (authResourceIdentifier == null) {
             determineAuthResourceIdentifier();
         }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/InvolvedConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/InvolvedConcepts.java
@@ -3,11 +3,11 @@ package at.ac.univie.mminf.qskos4j.issues.concepts;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,7 +26,7 @@ public class InvolvedConcepts extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         RepositoryResult<Statement> result = repCon.getStatements(
             null,
             RDF.TYPE,

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/OrphanConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/OrphanConcepts.java
@@ -4,12 +4,12 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.TupleQueryResultUtil;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQuery;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -35,7 +35,7 @@ public class OrphanConcepts extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createOrphanConceptsQuery());
         Set<Value> connectedConcepts = TupleQueryResultUtil.getValuesForBindingName(query.evaluate(), "concept");
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/UndocumentedConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/concepts/UndocumentedConcepts.java
@@ -4,12 +4,12 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BooleanQuery;
-import org.openrdf.query.QueryLanguage;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.QueryLanguage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +45,7 @@ public class UndocumentedConcepts extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
 		List<Resource> undocumentedConcepts = new ArrayList<Resource>();
 		
 		Iterator<Resource> conceptIt = new MonitoredIterator<Resource>(
@@ -80,7 +80,7 @@ public class UndocumentedConcepts extends Issue<CollectionResult<Resource>> {
                 createPropertyQuery(concept, property));
             return graphQuery.evaluate();
         }
-        catch (OpenRDFException e) {
+        catch (RDF4JException e) {
             logger.error("Error finding documentation properties of concept '" +concept+ "'");
         }
         return false;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/ConceptSchemes.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/ConceptSchemes.java
@@ -3,12 +3,12 @@ package at.ac.univie.mminf.qskos4j.issues.conceptscheme;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class ConceptSchemes extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         TupleQueryResult result = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createConceptSchemeQuery()).evaluate();
         return new CollectionResult<Resource>(identifyResources(result));
     }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/MappingRelationsMisuse.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/MappingRelationsMisuse.java
@@ -5,12 +5,12 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +30,7 @@ public class MappingRelationsMisuse extends Issue<CollectionResult<Statement>> {
     }
 
     @Override
-    protected CollectionResult<Statement> invoke() throws OpenRDFException {
+    protected CollectionResult<Statement> invoke() throws RDF4JException {
         Collection<Statement> problematicRelations = new ArrayList<Statement>();
 
         RepositoryResult<Statement> result = repCon.getStatements(
@@ -53,7 +53,7 @@ public class MappingRelationsMisuse extends Issue<CollectionResult<Statement>> {
         return new CollectionResult<Statement>(problematicRelations);
     }
 
-    private boolean areAuthoritativeConcepts(Resource... concepts) throws OpenRDFException {
+    private boolean areAuthoritativeConcepts(Resource... concepts) throws RDF4JException {
         for (Resource concept : concepts) {
             boolean isAuthoritativeConcept = false;
             for (Resource authoritativeConcept : authoritativeConcepts.getResult().getData()) {
@@ -65,11 +65,11 @@ public class MappingRelationsMisuse extends Issue<CollectionResult<Statement>> {
         return true;
     }
 
-    private boolean inSameConceptScheme(Resource concept, Resource otherConcept) throws OpenRDFException {
+    private boolean inSameConceptScheme(Resource concept, Resource otherConcept) throws RDF4JException {
         return repCon.prepareBooleanQuery(QueryLanguage.SPARQL, createInSchemeQuery(concept, otherConcept)).evaluate();
     }
 
-    private boolean inNoConceptScheme(Resource concept, Resource otherConcept) throws OpenRDFException {
+    private boolean inNoConceptScheme(Resource concept, Resource otherConcept) throws RDF4JException {
         boolean conceptInScheme = repCon.prepareBooleanQuery(QueryLanguage.SPARQL, createInSchemeQuery(concept)).evaluate();
         boolean otherConceptInScheme = repCon.prepareBooleanQuery(QueryLanguage.SPARQL, createInSchemeQuery(otherConcept)).evaluate();
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/OmittedTopConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/OmittedTopConcepts.java
@@ -3,12 +3,12 @@ package at.ac.univie.mminf.qskos4j.issues.conceptscheme;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BooleanQuery;
-import org.openrdf.query.QueryLanguage;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.QueryLanguage;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -34,7 +34,7 @@ public class OmittedTopConcepts extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         Collection<Resource> csWithOmittedTopConcepts = new HashSet<Resource>();
 
         for (Resource conceptScheme : conceptSchemes.getResult().getData()) {

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/TopConceptsHavingBroaderConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/conceptscheme/TopConceptsHavingBroaderConcepts.java
@@ -3,14 +3,14 @@ package at.ac.univie.mminf.qskos4j.issues.conceptscheme;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQuery;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,7 +32,7 @@ public class TopConceptsHavingBroaderConcepts extends Issue<CollectionResult<Val
     }
 
     @Override
-    protected CollectionResult<Value> invoke() throws OpenRDFException {
+    protected CollectionResult<Value> invoke() throws RDF4JException {
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createTopConceptsHavingBroaderConceptQuery());
         return new CollectionResult<Value>(createUriResultList(query.evaluate()));
     }
@@ -48,7 +48,7 @@ public class TopConceptsHavingBroaderConcepts extends Issue<CollectionResult<Val
                 "}";
     }
 
-    private Collection<Value> createUriResultList(TupleQueryResult result) throws OpenRDFException
+    private Collection<Value> createUriResultList(TupleQueryResult result) throws RDF4JException
     {
         List<Value> resultList = new ArrayList<Value>();
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/AggregationRelations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/AggregationRelations.java
@@ -4,9 +4,9 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.NumberResult;
 import at.ac.univie.mminf.qskos4j.util.TupleQueryResultUtil;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQuery;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
 
 /**
  * Created by christian
@@ -29,7 +29,7 @@ public class AggregationRelations extends Issue<NumberResult<Long>> {
     }
 
     @Override
-    protected NumberResult<Long> invoke() throws OpenRDFException {
+    protected NumberResult<Long> invoke() throws RDF4JException {
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createAggregationRelationsQuery());
         return new NumberResult<Long>(TupleQueryResultUtil.countResults(query.evaluate()));
     }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/Collections.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/Collections.java
@@ -3,10 +3,10 @@ package at.ac.univie.mminf.qskos4j.issues.count;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.NumberResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Statement;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 /**
  * Created by christian
@@ -26,7 +26,7 @@ public class Collections extends Issue<NumberResult<Long>> {
     }
 
     @Override
-    protected NumberResult<Long> invoke() throws OpenRDFException {
+    protected NumberResult<Long> invoke() throws RDF4JException {
         RepositoryResult<Statement> result = repCon.getStatements(null, RDF.TYPE, SkosOntology.getInstance().getUri("Collection"), true);
 
         long collectionCount = 0;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/SemanticRelations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/count/SemanticRelations.java
@@ -3,9 +3,9 @@ package at.ac.univie.mminf.qskos4j.issues.count;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.NumberResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Statement;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 /**
  * Created by christian
@@ -25,7 +25,7 @@ public class SemanticRelations extends Issue<NumberResult<Long>> {
     }
 
     @Override
-    protected NumberResult<Long> invoke() throws OpenRDFException {
+    protected NumberResult<Long> invoke() throws RDF4JException {
         RepositoryResult<Statement> result = repCon.getStatements(
             null,
             SkosOntology.getInstance().getUri("semanticRelation"),

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/cycles/HierarchicalCycles.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/cycles/HierarchicalCycles.java
@@ -6,10 +6,10 @@ import at.ac.univie.mminf.qskos4j.util.graph.NamedEdge;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.alg.CycleDetector;
 import org.jgrapht.alg.StrongConnectivityInspector;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ public class HierarchicalCycles extends Issue<HierarchicalCyclesResult> {
     }
 
     @Override
-    protected HierarchicalCyclesResult invoke() throws OpenRDFException {
+    protected HierarchicalCyclesResult invoke() throws RDF4JException {
         hierarchyGraph = hierarchyGraphBuilder.createGraph();
         return new HierarchicalCyclesResult(findCycleContainingComponents(), hierarchyGraph);
     }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/cycles/HierarchicalCyclesResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/cycles/HierarchicalCyclesResult.java
@@ -4,7 +4,7 @@ import at.ac.univie.mminf.qskos4j.result.ResourceCollectionsResult;
 import at.ac.univie.mminf.qskos4j.util.graph.GraphExporter;
 import at.ac.univie.mminf.qskos4j.util.graph.NamedEdge;
 import org.jgrapht.DirectedGraph;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/inlinks/MissingInLinks.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/inlinks/MissingInLinks.java
@@ -5,17 +5,17 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.ExtrapolatedCollectionResult;
 import at.ac.univie.mminf.qskos4j.util.RandomSubSet;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.sparql.SPARQLRepository;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public class MissingInLinks extends Issue<ExtrapolatedCollectionResult<Resource>
     }
 
     @Override
-    protected ExtrapolatedCollectionResult<Resource> invoke() throws OpenRDFException {
+    protected ExtrapolatedCollectionResult<Resource> invoke() throws RDF4JException {
         Collection<Resource> conceptsToCheck = getConceptsToCheck(randomSubsetSize_percent);
 
         if (randomSubsetSize_percent != null) {
@@ -68,7 +68,7 @@ public class MissingInLinks extends Issue<ExtrapolatedCollectionResult<Resource>
         return new ExtrapolatedCollectionResult<Resource>(extractUnreferencedConcepts(), randomSubsetSize_percent);
     }
 
-    private Collection<Resource> getConceptsToCheck(Float randomSubsetSize_percent) throws OpenRDFException
+    private Collection<Resource> getConceptsToCheck(Float randomSubsetSize_percent) throws RDF4JException
     {
 		if (randomSubsetSize_percent == null) {
 			return authoritativeConcepts.getResult().getData();
@@ -184,7 +184,7 @@ public class MissingInLinks extends Issue<ExtrapolatedCollectionResult<Resource>
      * Adds the repository containing the vocabulary that's about to test to the list of
      * other repositories. This is only useful for in-link testing purposes.
      */
-    public void addRepositoryLoopback() throws OpenRDFException {
+    public void addRepositoryLoopback() throws RDF4JException {
         connections.add(repCon);
     }
 
@@ -193,7 +193,7 @@ public class MissingInLinks extends Issue<ExtrapolatedCollectionResult<Resource>
      *
      * @param endpointUrl SPARL endpoint URL
      */
-    public void addSparqlEndPoint(String endpointUrl) throws OpenRDFException {
+    public void addSparqlEndPoint(String endpointUrl) throws RDF4JException {
         Repository repo = new SPARQLRepository(endpointUrl);
         repo.initialize();
         connections.add(repo.getConnection());

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/DisjointLabelsViolations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/DisjointLabelsViolations.java
@@ -5,10 +5,10 @@ import at.ac.univie.mminf.qskos4j.issues.labels.util.LabelConflict;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.LabeledConcept;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.ResourceLabelsCollector;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.LabelConflictsResult;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -36,18 +36,18 @@ public class DisjointLabelsViolations extends Issue<LabelConflictsResult> {
     }
 
     @Override
-    protected LabelConflictsResult invoke() throws OpenRDFException {
+    protected LabelConflictsResult invoke() throws RDF4JException {
         findNonDisjointLabels();
 
         return new LabelConflictsResult(nonDisjointLabels.values());
     }
 
-    private void findNonDisjointLabels() throws OpenRDFException {
+    private void findNonDisjointLabels() throws RDF4JException {
         Map<Literal, Collection<LabeledConcept>> resourcesByLabel = orderResourcesByLabel();
         extractNonDisjointConflicts(resourcesByLabel);
     }
 
-    private Map<Literal, Collection<LabeledConcept>> orderResourcesByLabel() throws OpenRDFException {
+    private Map<Literal, Collection<LabeledConcept>> orderResourcesByLabel() throws RDF4JException {
         Map<Literal, Collection<LabeledConcept>> resourcesByLabel = new HashMap<Literal, Collection<LabeledConcept>>();
 
         for (LabeledConcept labeledResource : resourceLabelsCollector.getLabeledConcepts()) {

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/EmptyLabeledResources.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/EmptyLabeledResources.java
@@ -4,13 +4,13 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.EmptyLabelsResult;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.LabelType;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.*;
 
@@ -23,7 +23,7 @@ public class EmptyLabeledResources extends Issue<EmptyLabelsResult> {
     }
 
     @Override
-    protected EmptyLabelsResult invoke() throws OpenRDFException {
+    protected EmptyLabelsResult invoke() throws RDF4JException {
         result = new HashMap<Resource, Collection<LabelType>>();
 
         TupleQueryResult result = repCon.prepareTupleQuery(

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/InconsistentPrefLabels.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/InconsistentPrefLabels.java
@@ -6,10 +6,10 @@ import at.ac.univie.mminf.qskos4j.issues.labels.util.LabelType;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.LabeledConcept;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.ResourceLabelsCollector;
 import at.ac.univie.mminf.qskos4j.issues.labels.util.LabelConflictsResult;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,14 +36,14 @@ public class InconsistentPrefLabels extends Issue<LabelConflictsResult> {
     }
 
     @Override
-    protected LabelConflictsResult invoke() throws OpenRDFException {
+    protected LabelConflictsResult invoke() throws RDF4JException {
         Map<Value, Collection<LabeledConcept>> prefLabelsByUri = orderPrefLabelsByResource();
         extractPrefLabelConflicts(prefLabelsByUri);
 
 		return new LabelConflictsResult(ambigPrefLabels.values());
 	}
 
-    private Map<Value, Collection<LabeledConcept>> orderPrefLabelsByResource() throws OpenRDFException {
+    private Map<Value, Collection<LabeledConcept>> orderPrefLabelsByResource() throws RDF4JException {
         Map<Value, Collection<LabeledConcept>> prefLabelsByResource = new HashMap<Value, Collection<LabeledConcept>>();
 
         for (LabeledConcept labeledConcept : resourceLabelsCollector.getLabeledConcepts()) {
@@ -90,8 +90,8 @@ public class InconsistentPrefLabels extends Issue<LabelConflictsResult> {
 
     private boolean hasPrefLabelConflict(LabeledConcept resource1, LabeledConcept resource2) {
         if (resource1 != resource2) {
-            String langRes1 = resource1.getLiteral().getLanguage();
-            String langRes2 = resource2.getLiteral().getLanguage();
+            String langRes1 = resource1.getLiteral().getLanguage().orElse(null);
+            String langRes2 = resource2.getLiteral().getLanguage().orElse(null);
 
             if (langRes1 != null && langRes2 != null) {
                 return langRes1.equals(langRes2);

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/LexicalRelations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/LexicalRelations.java
@@ -5,10 +5,10 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.InvolvedConcepts;
 import at.ac.univie.mminf.qskos4j.result.NumberResult;
 import at.ac.univie.mminf.qskos4j.util.TupleQueryResultUtil;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Value;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,7 @@ public class LexicalRelations extends Issue<NumberResult<Long>> {
     }
 
     @Override
-    protected NumberResult<Long> invoke() throws OpenRDFException {
+    protected NumberResult<Long> invoke() throws RDF4JException {
         long relationsCount = 0;
 
         for (Value concept : involvedConcepts.getResult().getData()) {
@@ -50,7 +50,7 @@ public class LexicalRelations extends Issue<NumberResult<Long>> {
 
                 relationsCount += TupleQueryResultUtil.countResults(result);
             }
-            catch (OpenRDFException e) {
+            catch (RDF4JException e) {
                 logger.error("Error finding labels for concept '" +concept+ "'", e);
             }
         }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/MissingLabels.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/MissingLabels.java
@@ -5,12 +5,12 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.issues.conceptscheme.ConceptSchemes;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public class MissingLabels extends Issue<CollectionResult<Resource>> {
     }
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
         unlabeledConceptsAndConceptSchemes = new ArrayList<Resource>();
 
         unlabeledConceptsAndConceptSchemes.addAll(findUnlabeledConcepts());
@@ -46,7 +46,7 @@ public class MissingLabels extends Issue<CollectionResult<Resource>> {
         return new CollectionResult<Resource>(unlabeledConceptsAndConceptSchemes);
     }
 
-    private Collection<Resource> findUnlabeledConcepts() throws OpenRDFException {
+    private Collection<Resource> findUnlabeledConcepts() throws RDF4JException {
         Collection<Resource> unlabeledConcepts = new ArrayList<Resource>();
 
         for (Resource authConcept : allAuthConcepts.getResult().getData()) {
@@ -62,13 +62,13 @@ public class MissingLabels extends Issue<CollectionResult<Resource>> {
         try {
             return !repCon.prepareBooleanQuery(QueryLanguage.SPARQL, prefLabelQuery).evaluate();
         }
-        catch (OpenRDFException e) {
+        catch (RDF4JException e) {
             logger.error("Error finding preferred label of concept '" +concept.stringValue()+ "'");
             return false;
         }
     }
 
-    private Collection<Resource> findUnlabeledConceptSchemes() throws OpenRDFException {
+    private Collection<Resource> findUnlabeledConceptSchemes() throws RDF4JException {
         Collection<Resource> unlabeledConceptSchemes = new ArrayList<Resource>();
 
         for (Resource conceptScheme : allConceptSchemes.getResult().getData()) {
@@ -78,7 +78,7 @@ public class MissingLabels extends Issue<CollectionResult<Resource>> {
         return unlabeledConceptSchemes;
     }
 
-    private boolean hasNoRdfsLabelAndNoDcTitle(Value conceptScheme) throws OpenRDFException {
+    private boolean hasNoRdfsLabelAndNoDcTitle(Value conceptScheme) throws RDF4JException {
         String labelQuery = SparqlPrefix.RDFS +" "+ SparqlPrefix.DC +" "+ SparqlPrefix.DCTERMS+
             " ASK {" +
                 "{<" +conceptScheme+ "> rdfs:label ?label} UNION " +

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/OverlappingLabels.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/OverlappingLabels.java
@@ -9,12 +9,12 @@ import at.ac.univie.mminf.qskos4j.issues.labels.util.SimilarityLiteral;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.*;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,14 +45,14 @@ public class OverlappingLabels extends Issue<CollectionResult<LabelConflict>> {
     }
 
     @Override
-    protected CollectionResult<LabelConflict> invoke() throws OpenRDFException {
+    protected CollectionResult<LabelConflict> invoke() throws RDF4JException {
         generateConceptsLabelMap();
         generateLabelConflictResults();
 
 		return new CollectionResult<LabelConflict>(labelConflicts);
 	}
 
-    private void generateConceptsLabelMap() throws OpenRDFException
+    private void generateConceptsLabelMap() throws RDF4JException
 	{
 		conceptLabels = new HashMap<Literal, Set<LabeledConcept>>();
         Iterator<Resource> it = new MonitoredIterator<Resource>(involvedConcepts.getResult().getData(), progressMonitor);
@@ -66,7 +66,7 @@ public class OverlappingLabels extends Issue<CollectionResult<LabelConflict>> {
                 Set<LabeledConcept> labeledConcepts = createLabeledConceptsFromResult(concept, query.evaluate());
                 addToLabelsMap(labeledConcepts);
             }
-            catch (OpenRDFException e) {
+            catch (RDF4JException e) {
                 logger.error("Error finding labels of concept '" +concept+ "'");
             }
 		}

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/EmptyLabelsResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/EmptyLabelsResult.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelConflict.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelConflict.java
@@ -1,6 +1,6 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelConflictsResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelConflictsResult.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelType.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabelType.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.model.URI;
+import org.eclipse.rdf4j.model.URI;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabeledConcept.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/LabeledConcept.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
 
 public class LabeledConcept {
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/ResourceLabelsCollector.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/ResourceLabelsCollector.java
@@ -1,13 +1,13 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class ResourceLabelsCollector {
                 TupleQueryResult result = repCon.prepareTupleQuery(QueryLanguage.SPARQL, labelQuery).evaluate();
                 addResultToLabels(labelType, result);
             }
-            catch (OpenRDFException e) {
+            catch (RDF4JException e) {
                 logger.error("error querying repository: " +labelQuery);
             }
         }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/SimilarityLiteral.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/SimilarityLiteral.java
@@ -1,14 +1,15 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
-import org.openrdf.model.Literal;
-import org.openrdf.model.impl.LiteralImpl;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.LiteralImpl;
 
 public class SimilarityLiteral extends LiteralImpl{
 
     public SimilarityLiteral(Literal literal) {
-        super();
-        setLabel(literal.getLabel().toUpperCase());
-        setLanguage(literal.getLanguage());
+        super(literal.getLabel().toUpperCase());
+        if(literal.getLanguage().isPresent()) {
+        	setLanguage(literal.getLanguage().get());
+        }
         setDatatype(literal.getDatatype());
     }
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/UriSuffixFinder.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/labels/util/UriSuffixFinder.java
@@ -1,6 +1,6 @@
 package at.ac.univie.mminf.qskos4j.issues.labels.util;
 
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.model.Value;
 
 import java.util.Collection;
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/IncompleteLangCovResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/IncompleteLangCovResult.java
@@ -2,7 +2,7 @@ package at.ac.univie.mminf.qskos4j.issues.language;
 
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/IncompleteLanguageCoverage.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/IncompleteLanguageCoverage.java
@@ -2,9 +2,9 @@ package at.ac.univie.mminf.qskos4j.issues.language;
 
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.issues.language.util.LanguageCoverage;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class IncompleteLanguageCoverage extends Issue<IncompleteLangCovResult> {
     }
 
     @Override
-    protected IncompleteLangCovResult invoke() throws OpenRDFException {
+    protected IncompleteLangCovResult invoke() throws RDF4JException {
 		incompleteLanguageCoverage = new HashMap<Resource, Collection<String>>();
 
         findDistinctLanguages();
@@ -43,14 +43,14 @@ public class IncompleteLanguageCoverage extends Issue<IncompleteLangCovResult> {
 		return new IncompleteLangCovResult(incompleteLanguageCoverage);
 	}
 
-    private void findDistinctLanguages() throws OpenRDFException {
+    private void findDistinctLanguages() throws RDF4JException {
         distinctLanguages = new HashSet<String>();
         for (Collection languages : languageCoverage.getResult().getData().values()) {
             distinctLanguages.addAll(languages);
         }
     }
 
-	private void generateIncompleteLanguageCoverageMap() throws OpenRDFException {
+	private void generateIncompleteLanguageCoverageMap() throws RDF4JException {
 		incompleteLanguageCoverage = new HashMap<Resource, Collection<String>>();
 
         Map<Resource, Collection<String>> langCovData = languageCoverage.getResult().getData();

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/NoCommonLanguages.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/NoCommonLanguages.java
@@ -3,8 +3,8 @@ package at.ac.univie.mminf.qskos4j.issues.language;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.issues.language.util.NoCommonLanguagesResult;
 import at.ac.univie.mminf.qskos4j.issues.language.util.LanguageCoverage;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -27,7 +27,7 @@ public class NoCommonLanguages extends Issue<NoCommonLanguagesResult> {
     }
 
     @Override
-    protected NoCommonLanguagesResult invoke() throws OpenRDFException {
+    protected NoCommonLanguagesResult invoke() throws RDF4JException {
         Map<Resource, Collection<String>> langCovData = languageCoverage.getResult().getData();
         commonLanguages = new HashSet<String>();
 
@@ -39,7 +39,7 @@ public class NoCommonLanguages extends Issue<NoCommonLanguagesResult> {
         return new NoCommonLanguagesResult(commonLanguages);
     }
 
-    private void findCommonLanguages() throws OpenRDFException {
+    private void findCommonLanguages() throws RDF4JException {
         for (Map.Entry<Resource, Collection<String>> entry : languageCoverage.getResult().getData().entrySet()) {
             commonLanguages.retainAll(entry.getValue());
         }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/OmittedOrInvalidLanguageTags.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/OmittedOrInvalidLanguageTags.java
@@ -3,14 +3,14 @@ package at.ac.univie.mminf.qskos4j.issues.language;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.*;
 
@@ -32,7 +32,7 @@ public class OmittedOrInvalidLanguageTags extends Issue<OmittedOrInvalidLanguage
     }
 
     @Override
-    protected OmittedOrInvalidLanguageTagsResult invoke() throws OpenRDFException {
+    protected OmittedOrInvalidLanguageTagsResult invoke() throws RDF4JException {
         TupleQueryResult result = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createMissingLangTagQuery()).evaluate();
         generateMissingLangTagMap(result);
 
@@ -71,11 +71,12 @@ public class OmittedOrInvalidLanguageTags extends Issue<OmittedOrInvalidLanguage
     }
 
     private boolean hasNoOrInvalidTag(Literal literal) {
-        if (literal.getDatatype() == null) {
-            String langTag = literal.getLanguage();
+        if (literal.getLanguage().isPresent()) {
+            String langTag = literal.getLanguage().orElse(null);
             return langTag == null || !isValidLangTag(langTag);
+        } else {
+        	return true;
         }
-        return false;
     }
 
     private boolean isValidLangTag(String langTag) {

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/OmittedOrInvalidLanguageTagsResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/OmittedOrInvalidLanguageTagsResult.java
@@ -2,8 +2,8 @@ package at.ac.univie.mminf.qskos4j.issues.language;
 
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/util/LanguageCoverage.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/util/LanguageCoverage.java
@@ -3,11 +3,11 @@ package at.ac.univie.mminf.qskos4j.issues.language.util;
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.issues.concepts.InvolvedConcepts;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.query.*;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class LanguageCoverage extends Issue<LanguageCoverageResult> {
     }
 
     @Override
-    protected LanguageCoverageResult invoke() throws OpenRDFException {
+    protected LanguageCoverageResult invoke() throws RDF4JException {
         languageCoverage = new HashMap<Resource, Collection<String>>();
 
         Iterator<Resource> it = new MonitoredIterator<Resource>(involvedConcepts.getResult().getData(), progressMonitor);
@@ -42,7 +42,7 @@ public class LanguageCoverage extends Issue<LanguageCoverageResult> {
                 TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createLanguageLiteralQuery(concept));
                 addToLanguageCoverageMap(concept, query.evaluate());
             }
-            catch (OpenRDFException e) {
+            catch (RDF4JException e) {
                 logger.error("Error finding languages for concept '" +concept+ "'");
             }
         }
@@ -64,7 +64,7 @@ public class LanguageCoverage extends Issue<LanguageCoverageResult> {
             BindingSet queryResult = result.next();
             Literal literal = (Literal) queryResult.getValue("literal");
 
-            String language = literal.getLanguage();
+            String language = literal.getLanguage().orElse(null);
             addToLanguageCoverageMap(concept, language);
         }
     }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/util/LanguageCoverageResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/language/util/LanguageCoverageResult.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.issues.language.util;
 
 import at.ac.univie.mminf.qskos4j.result.Result;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.util.Collection;
 import java.util.Map;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/BrokenLinks.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/BrokenLinks.java
@@ -7,8 +7,8 @@ import at.ac.univie.mminf.qskos4j.util.RandomSubSet;
 import at.ac.univie.mminf.qskos4j.util.url.NoContentTypeProvidedException;
 import at.ac.univie.mminf.qskos4j.util.url.UrlDereferencer;
 import at.ac.univie.mminf.qskos4j.util.url.UrlNotDereferencableException;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.impl.URIImpl;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.impl.URIImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,12 +48,12 @@ public class BrokenLinks extends Issue<ExtrapolatedCollectionResult<URL>> {
 	}
 
     @Override
-    protected ExtrapolatedCollectionResult<URL> invoke() throws OpenRDFException {
+    protected ExtrapolatedCollectionResult<URL> invoke() throws RDF4JException {
         dereferenceURIs();
 		return new ExtrapolatedCollectionResult<URL>(collectUnavailableURLs(), randomSubsetSize_percent);
 	}
 
-    private void dereferenceURIs() throws OpenRDFException
+    private void dereferenceURIs() throws RDF4JException
 	{
 		Collection<URI> urisToBeDereferenced = collectUrisToBeDereferenced();
 		Iterator<URI> it = new MonitoredIterator<URI>(urisToBeDereferenced, progressMonitor);
@@ -77,7 +77,7 @@ public class BrokenLinks extends Issue<ExtrapolatedCollectionResult<URL>> {
 		}
 	}
 	
-	private Collection<URI> collectUrisToBeDereferenced() throws OpenRDFException {
+	private Collection<URI> collectUrisToBeDereferenced() throws RDF4JException {
 		if (randomSubsetSize_percent == null) {
 			return httpURIs.getResult().getData();
 		}

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/HttpURIs.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/HttpURIs.java
@@ -2,11 +2,11 @@ package at.ac.univie.mminf.qskos4j.issues.outlinks;
 
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Value;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +31,7 @@ public class HttpURIs extends Issue<CollectionResult<URI>> {
     }
 
     @Override
-    protected CollectionResult<URI> invoke() throws OpenRDFException {
+    protected CollectionResult<URI> invoke() throws RDF4JException {
         RepositoryResult<Statement> result = repCon.getStatements(null, null, null, false, (Resource) null);
         while (result.hasNext()) {
             Statement st = result.next();
@@ -40,7 +40,7 @@ public class HttpURIs extends Issue<CollectionResult<URI>> {
             tripleValues.addAll(Arrays.asList(st.getSubject(), st.getObject(), st.getPredicate()));
 
             for (Value value : tripleValues) {
-                if (value instanceof org.openrdf.model.URI) addToUrlList(value);
+                if (value instanceof org.eclipse.rdf4j.model.IRI) addToUrlList(value);
             }
         }
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/HttpUriSchemeViolations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/HttpUriSchemeViolations.java
@@ -2,12 +2,12 @@ package at.ac.univie.mminf.qskos4j.issues.outlinks;
 
 import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,7 +31,7 @@ public class HttpUriSchemeViolations extends Issue<CollectionResult<String>> {
     }
 
     @Override
-    protected CollectionResult<String> invoke() throws OpenRDFException {
+    protected CollectionResult<String> invoke() throws RDF4JException {
         Set<String> nonHttpURIs = new HashSet<String>();
 
         RepositoryResult<Statement> allStatements = repCon.getStatements(null, null, null, false);

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/MissingOutLinks.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/outlinks/MissingOutLinks.java
@@ -5,14 +5,14 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.util.*;
 
@@ -37,7 +37,7 @@ public class MissingOutLinks extends Issue<CollectionResult<Resource>> {
 	}
 
     @Override
-    protected CollectionResult<Resource> invoke() throws OpenRDFException {
+    protected CollectionResult<Resource> invoke() throws RDF4JException {
 		extResourcesForConcept = new HashMap<Resource, Collection<URI>>();
 
 		findResourcesForConcepts(authoritativeConcepts.getResult().getData());
@@ -45,7 +45,7 @@ public class MissingOutLinks extends Issue<CollectionResult<Resource>> {
 		return new CollectionResult<Resource>(extractUnlinkedConcepts());
 	}
 
-    private void findResourcesForConcepts(Collection<Resource> concepts) throws OpenRDFException {
+    private void findResourcesForConcepts(Collection<Resource> concepts) throws RDF4JException {
 		Iterator<Resource> conceptIt = new MonitoredIterator<Resource>(concepts, progressMonitor, "finding resources");
 
 		while (conceptIt.hasNext()) {
@@ -76,7 +76,7 @@ public class MissingOutLinks extends Issue<CollectionResult<Resource>> {
         if (value instanceof URI) uris.add((URI) value);
     }
 	
-	private Collection<URI> extractExternalResources(Collection<URI> allResources) throws OpenRDFException {
+	private Collection<URI> extractExternalResources(Collection<URI> allResources) throws RDF4JException {
 		Collection<URI> validExternalResources = new HashSet<URI>();
 		
 		for (URI uri : allResources) {
@@ -88,7 +88,7 @@ public class MissingOutLinks extends Issue<CollectionResult<Resource>> {
 		return validExternalResources;
 	}
 	
-	private boolean isExternalResource(URI url) throws OpenRDFException {
+	private boolean isExternalResource(URI url) throws RDF4JException {
         String authResourceIdentifier = authoritativeConcepts.getAuthResourceIdentifier();
 
         if (authResourceIdentifier != null && !authResourceIdentifier.isEmpty()) {

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/ReflexivelyRelatedConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/ReflexivelyRelatedConcepts.java
@@ -5,14 +5,14 @@ import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.progress.MonitoredIterator;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.impl.StatementImpl;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.impl.StatementImpl;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +37,11 @@ public class ReflexivelyRelatedConcepts extends Issue<CollectionResult<Statement
     }
 
     @Override
-    protected CollectionResult<Statement> invoke() throws OpenRDFException {
+    protected CollectionResult<Statement> invoke() throws RDF4JException {
         return new CollectionResult<>(findReflexivelyRelatedResources());
     }
 
-    private Collection<Statement> findReflexivelyRelatedResources() throws OpenRDFException
+    private Collection<Statement> findReflexivelyRelatedResources() throws RDF4JException
     {
         Collection<Statement> results = new ArrayList<>();
 
@@ -69,13 +69,13 @@ public class ReflexivelyRelatedConcepts extends Issue<CollectionResult<Statement
                     "?relation rdfs:subPropertyOf skos:semanticRelation " +
                 "}").evaluate();
         }
-        catch (OpenRDFException e) {
+        catch (RDF4JException e) {
             logger.error("Error finding relations of concept '" +resource+ "'");
         }
         return false;
     }
 
-    private boolean isAuthoritativeConcept(Resource resource) throws OpenRDFException {
+    private boolean isAuthoritativeConcept(Resource resource) throws RDF4JException {
         return authoritativeConcepts.getResult().getData().contains(resource);
     }
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/SolelyTransitivelyRelatedConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/SolelyTransitivelyRelatedConcepts.java
@@ -4,14 +4,14 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.StatementImpl;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.*;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.StatementImpl;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +38,7 @@ public class SolelyTransitivelyRelatedConcepts extends Issue<CollectionResult<Tu
     }
 
     @Override
-    protected CollectionResult<Tuple<Resource>> invoke() throws OpenRDFException {
+    protected CollectionResult<Tuple<Resource>> invoke() throws RDF4JException {
         solitaryTransitiveRelations = new ArrayList<Statement>();
         for (String[] transitivePropertyPair : transitiveNontransiviteInverseProperties) {
             String query = createSolitaryTransitiveRelationsQuery(transitivePropertyPair);

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/UnidirectionallyRelatedConcepts.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/UnidirectionallyRelatedConcepts.java
@@ -4,11 +4,11 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.issues.concepts.AuthoritativeConcepts;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.*;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class UnidirectionallyRelatedConcepts extends Issue<UnidirectionallyRelat
     }
 
     @Override
-    protected UnidirectionallyRelatedConceptsResult invoke() throws OpenRDFException {
+    protected UnidirectionallyRelatedConceptsResult invoke() throws RDF4JException {
         String authResourceIdentifier = authoritativeConcepts.getAuthResourceIdentifier();
 
         for (String[] inversePropertyPair : inversePropertyPairs) {

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/UnidirectionallyRelatedConceptsResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/UnidirectionallyRelatedConceptsResult.java
@@ -3,7 +3,7 @@ package at.ac.univie.mminf.qskos4j.issues.relations;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.result.Result;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/ValuelessAssociativeRelations.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/relations/ValuelessAssociativeRelations.java
@@ -4,10 +4,10 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.*;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.*;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -26,7 +26,7 @@ public class ValuelessAssociativeRelations extends Issue<CollectionResult<Tuple<
     }
 
     @Override
-    protected CollectionResult<Tuple<URI>> invoke() throws OpenRDFException {
+    protected CollectionResult<Tuple<URI>> invoke() throws RDF4JException {
         Collection<Tuple<URI>> redundantAssociativeRelations = new HashSet<Tuple<URI>>();
 
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createRedundantAssociativeRelationsQuery());

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/HierarchicalRedundancy.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/HierarchicalRedundancy.java
@@ -4,12 +4,12 @@ import at.ac.univie.mminf.qskos4j.issues.Issue;
 import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -28,7 +28,7 @@ public class HierarchicalRedundancy extends Issue<CollectionResult<Tuple<Resourc
     }
 
     @Override
-    protected CollectionResult<Tuple<Resource>> invoke() throws OpenRDFException {
+    protected CollectionResult<Tuple<Resource>> invoke() throws RDF4JException {
         hierarchicalRedundancies = new HashSet<Tuple<Resource>>();
 
         TupleQueryResult result = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createQuery()).evaluate();

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/MappingClashes.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/MappingClashes.java
@@ -5,11 +5,11 @@ import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.Tuple;
 import at.ac.univie.mminf.qskos4j.util.TupleQueryResultUtil;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQuery;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -29,7 +29,7 @@ public class MappingClashes extends Issue<CollectionResult<Tuple<Resource>>> {
     }
 
     @Override
-    protected CollectionResult<Tuple<Resource>> invoke() throws OpenRDFException {
+    protected CollectionResult<Tuple<Resource>> invoke() throws RDF4JException {
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createExVsAssMappingQuery());
 
         Collection<Tuple<Resource>> valuePairs = TupleQueryResultUtil.createCollectionOfResourcePairs(

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/RelationClashes.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/RelationClashes.java
@@ -10,12 +10,12 @@ import at.ac.univie.mminf.qskos4j.util.graph.NamedEdge;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.DijkstraShortestPath;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -40,7 +40,7 @@ public class RelationClashes extends Issue<CollectionResult<Tuple<Resource>>> {
     }
 
     @Override
-    protected CollectionResult<Tuple<Resource>> invoke() throws OpenRDFException {
+    protected CollectionResult<Tuple<Resource>> invoke() throws RDF4JException {
         Graph<Resource, NamedEdge> hierarchyGraph = hierarchyGraphBuilder.createGraph();
 
         Collection<Tuple<Resource>> clashes = new HashSet<Tuple<Resource>>();
@@ -64,7 +64,7 @@ public class RelationClashes extends Issue<CollectionResult<Tuple<Resource>>> {
         return new CollectionResult<Tuple<Resource>>(clashes);
     }
 
-    private Collection<Tuple<Resource>> findRelatedConcepts() throws OpenRDFException {
+    private Collection<Tuple<Resource>> findRelatedConcepts() throws RDF4JException {
         TupleQueryResult result = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createRelatedConceptsQuery()).evaluate();
         return TupleQueryResultUtil.createCollectionOfResourcePairs(result, "concept1", "concept2");
     }

--- a/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/UndefinedSkosResources.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/issues/skosintegrity/UndefinedSkosResources.java
@@ -5,12 +5,12 @@ import at.ac.univie.mminf.qskos4j.result.CollectionResult;
 import at.ac.univie.mminf.qskos4j.util.TupleQueryResultUtil;
 import at.ac.univie.mminf.qskos4j.util.vocab.SkosOntology;
 import at.ac.univie.mminf.qskos4j.util.vocab.SparqlPrefix;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.*;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -36,14 +36,14 @@ public class UndefinedSkosResources extends Issue<CollectionResult<URI>> {
     }
 
     @Override
-    protected CollectionResult<URI> invoke() throws OpenRDFException {
+    protected CollectionResult<URI> invoke() throws RDF4JException {
 		findDeprecatedProperties();
 		findIllegalTerms();
 		
 		return new CollectionResult<URI>(collectUndefinedResources());
 	}
 
-    private void findDeprecatedProperties() throws OpenRDFException
+    private void findDeprecatedProperties() throws RDF4JException
 	{
 		TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createDeprecatedPropertiesQuery());
 		generateDeprecatedPropertiesMap(query.evaluate());
@@ -86,13 +86,13 @@ public class UndefinedSkosResources extends Issue<CollectionResult<URI>> {
 		}
 	}
 	
-	private void findIllegalTerms() throws OpenRDFException 
+	private void findIllegalTerms() throws RDF4JException 
 	{
         TupleQuery query = repCon.prepareTupleQuery(QueryLanguage.SPARQL, createIllegalTermsQuery());
 		generateIllegalTermsMap(query.evaluate());
 	}
 	
-	private String createIllegalTermsQuery() throws OpenRDFException {
+	private String createIllegalTermsQuery() throws RDF4JException {
 		return SparqlPrefix.SKOS+ 
 			"SELECT DISTINCT ?illTerm ?s ?o "+
 			"WHERE {" +
@@ -105,7 +105,7 @@ public class UndefinedSkosResources extends Issue<CollectionResult<URI>> {
             "} ";
 	}
 
-    private String createSkosSubjectsFilter() throws OpenRDFException {
+    private String createSkosSubjectsFilter() throws RDF4JException {
         RepositoryConnection skosRepoConn = SkosOntology.getInstance().getRepository().getConnection();
         try {
             TupleQuery skosSubjectsQuery = skosRepoConn.prepareTupleQuery(QueryLanguage.SPARQL, createSkosSubjectsQuery());

--- a/src/main/java/at/ac/univie/mminf/qskos4j/result/ResourceCollectionsResult.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/result/ResourceCollectionsResult.java
@@ -1,7 +1,7 @@
 package at.ac.univie.mminf.qskos4j.result;
 
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/util/TupleQueryResultUtil.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/util/TupleQueryResultUtil.java
@@ -1,11 +1,11 @@
 package at.ac.univie.mminf.qskos4j.util;
 
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.TupleQueryResult;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.*;
 
@@ -46,7 +46,7 @@ public class TupleQueryResultUtil {
     }
 
     public static Collection<Tuple<Resource>> createCollectionOfResourcePairs(TupleQueryResult result, String value1, String value2)
-        throws OpenRDFException
+        throws RDF4JException
     {
         Collection<Tuple<Resource>> resultCollection = new ArrayList<Tuple<Resource>>();
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/util/graph/GraphExporter.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/util/graph/GraphExporter.java
@@ -7,7 +7,7 @@ import org.jgrapht.ext.IntegerNameProvider;
 import org.jgrapht.ext.StringEdgeNameProvider;
 import org.jgrapht.ext.VertexNameProvider;
 import org.jgrapht.graph.DirectedSubgraph;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.StringWriter;
 import java.util.Collection;

--- a/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/RepositoryBuilder.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/RepositoryBuilder.java
@@ -1,19 +1,19 @@
 package at.ac.univie.mminf.qskos4j.util.vocab;
 
 import org.junit.Assert;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Statement;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.query.GraphQuery;
-import org.openrdf.query.GraphQueryResult;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.sail.inferencer.fc.ForwardChainingRDFSInferencer;
-import org.openrdf.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +27,7 @@ public class RepositoryBuilder {
 
     private Repository repository;
 
-    public Repository setUpFromTestResource(String testFileName) throws OpenRDFException, IOException {
+    public Repository setUpFromTestResource(String testFileName) throws RDF4JException, IOException {
         URL conceptsUrl = RepositoryBuilder.class.getResource("/" +testFileName);
         File conceptsFile = new File(conceptsUrl.getFile());
         Assert.assertNotNull(conceptsFile);
@@ -36,7 +36,7 @@ public class RepositoryBuilder {
     }
 
     public Repository setUpFromFile(File rdfFile, String baseURI, RDFFormat dataFormat)
-        throws OpenRDFException, IOException
+        throws RDF4JException, IOException
     {
         logger.info("Initializing evaluation repository...");
 
@@ -63,7 +63,7 @@ public class RepositoryBuilder {
         repository.initialize();
     }
 
-    private void addSkosOntology() throws OpenRDFException, IOException {
+    private void addSkosOntology() throws RDF4JException, IOException {
         repository.getConnection().add(
             new URL(SkosOntology.SKOS_ONTO_URI),
             SkosOntology.SKOS_BASE_URI,
@@ -82,17 +82,17 @@ public class RepositoryBuilder {
      * as described in the SKOS <a href="http://www.w3.org/TR/skos-reference/#S55">reference document</a> by the axioms
      * S55-S57
      *
-     * @throws org.openrdf.OpenRDFException if errors when initializing local repository
+     * @throws org.openrdf.RDF4JException if errors when initializing local repository
      */
     public void enableSkosXlSupport()
-            throws OpenRDFException
+            throws RDF4JException
     {
         addSkosXlLabels("skosxl:prefLabel", "skos:prefLabel");
         addSkosXlLabels("skosxl:altLabel", "skos:altLabel");
         addSkosXlLabels("skosxl:hiddenLabel", "skos:hiddenLabel");
     }
 
-    private void addSkosXlLabels(String skosXlProperty, String skosProperty) throws OpenRDFException
+    private void addSkosXlLabels(String skosXlProperty, String skosProperty) throws RDF4JException
     {
         RepositoryConnection repCon = repository.getConnection();
 
@@ -113,7 +113,7 @@ public class RepositoryBuilder {
     private GraphQuery createSkosXlGraphQuery(
             RepositoryConnection connection,
             String skosXlProperty,
-            String skosProperty) throws OpenRDFException
+            String skosProperty) throws RDF4JException
     {
         return connection.prepareGraphQuery(
                 QueryLanguage.SPARQL,

--- a/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/SkosOntology.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/SkosOntology.java
@@ -1,14 +1,14 @@
 package at.ac.univie.mminf.qskos4j.util.vocab;
 
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.URI;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.impl.URIImpl;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public class SkosOntology {
         return ourInstance;
     }
 
-    private void createSkosRepo() throws OpenRDFException, IOException {
+    private void createSkosRepo() throws RDF4JException, IOException {
         skosRepo = new SailRepository(new MemoryStore());
         skosRepo.initialize();
 

--- a/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/SparqlPrefix.java
+++ b/src/main/java/at/ac/univie/mminf/qskos4j/util/vocab/SparqlPrefix.java
@@ -6,8 +6,8 @@ public enum SparqlPrefix {
 	SKOSXL("skosxl", "http://www.w3.org/2008/05/skos-xl#"),
     DC("dc", "http://purl.org/dc/elements/1.1/"),
     DCTERMS("dcterms", "http://purl.org/dc/terms/"),
-	RDF("rdf", org.openrdf.model.vocabulary.RDF.NAMESPACE),
-	RDFS("rdfs", org.openrdf.model.vocabulary.RDFS.NAMESPACE);
+	RDF("rdf", org.eclipse.rdf4j.model.vocabulary.RDF.NAMESPACE),
+	RDFS("rdfs", org.eclipse.rdf4j.model.vocabulary.RDFS.NAMESPACE);
 
 	private String abbrv, nameSpace;
 	

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/AggregationRelationsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/AggregationRelationsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,13 +19,13 @@ public class AggregationRelationsTest {
     private AggregationRelations aggregationRelations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         aggregationRelations = new AggregationRelations();
         aggregationRelations.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("aggregations.rdf").getConnection());
     }
 
     @Test
-    public void testAggregationRelationsCount() throws OpenRDFException
+    public void testAggregationRelationsCount() throws RDF4JException
     {
         Assert.assertEquals(6, aggregationRelations.getResult().getData().longValue());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/AuthoritativeConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/AuthoritativeConceptsTest.java
@@ -6,8 +6,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -22,14 +22,14 @@ public class AuthoritativeConceptsTest {
     private AuthoritativeConcepts authoritativeConcepts;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         authoritativeConcepts = new AuthoritativeConcepts(new InvolvedConcepts());
         authoritativeConcepts.setAuthResourceIdentifier("zbw.eu");
         authoritativeConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
     }
 
     @Test
-    public void testAuthoritativeConceptsCount() throws OpenRDFException
+    public void testAuthoritativeConceptsCount() throws RDF4JException
     {
         Collection<Resource> authoritativeConceptValues = authoritativeConcepts.getResult().getData();
         Assert.assertEquals(9, authoritativeConceptValues.size());

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/BrokenLinksTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/BrokenLinksTest.java
@@ -7,7 +7,7 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 import java.net.URL;
@@ -23,7 +23,7 @@ public class BrokenLinksTest {
     private BrokenLinks brokenLinks;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         brokenLinks = new BrokenLinks(new HttpURIs());
         brokenLinks.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("resources.rdf").getConnection());
         brokenLinks.setExtAccessDelayMillis(0);
@@ -31,7 +31,7 @@ public class BrokenLinksTest {
 
     @Ignore
     @Test
-    public void testBrokenLinks() throws OpenRDFException {
+    public void testBrokenLinks() throws RDF4JException {
         Collection<URL> brokenLinkURLs = brokenLinks.getResult().getData();
         Assert.assertEquals(1, brokenLinkURLs.size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/CollectionsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/CollectionsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,13 +19,13 @@ public class CollectionsTest {
     private Collections collections;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         collections = new Collections();
         collections.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("aggregations.rdf").getConnection());
     }
 
     @Test
-    public void testCollectionsCount() throws OpenRDFException
+    public void testCollectionsCount() throws RDF4JException
     {
         Assert.assertEquals(4, collections.getResult().getData().longValue());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/ConceptSchemesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/ConceptSchemesTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,13 +19,13 @@ public class ConceptSchemesTest {
     private ConceptSchemes conceptSchemes;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         conceptSchemes = new ConceptSchemes();
         conceptSchemes.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("aggregations.rdf").getConnection());
     }
 
     @Test
-    public void testLexicalRelationsCount() throws OpenRDFException
+    public void testLexicalRelationsCount() throws RDF4JException
     {
         Assert.assertEquals(3, conceptSchemes.getResult().getData().size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/DisconnectedConceptClustersTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/DisconnectedConceptClustersTest.java
@@ -6,8 +6,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -23,14 +23,14 @@ public class DisconnectedConceptClustersTest {
     private InvolvedConcepts involvedConcepts;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         involvedConcepts = new InvolvedConcepts();
         disconnectedConceptClusters = new DisconnectedConceptClusters(involvedConcepts);
         disconnectedConceptClusters.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
     }
 
     @Test
-    public void testComponentCount() throws OpenRDFException {
+    public void testComponentCount() throws RDF4JException {
         long conceptCount = involvedConcepts.getResult().getData().size();
         Collection<Collection<Resource>> components = disconnectedConceptClusters.getResult().getData();
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/DisjointLabelsViolationsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/DisjointLabelsViolationsTest.java
@@ -8,7 +8,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -18,13 +18,13 @@ public class DisjointLabelsViolationsTest {
     private DisjointLabelsViolations disjointLabelsViolations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         disjointLabelsViolations = new DisjointLabelsViolations(new ResourceLabelsCollector());
         disjointLabelsViolations.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("ambiguousLabels.rdf").getConnection());
     }
 
     @Test
-    public void testDisjointLabels() throws OpenRDFException {
+    public void testDisjointLabels() throws RDF4JException {
         Collection<LabelConflict> ambiguousResources = disjointLabelsViolations.getResult().getData();
 
         Assert.assertTrue(UriSuffixFinder.isPartOfConflict(ambiguousResources, "conceptD"));

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/EmptyLabeledResourcesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/EmptyLabeledResourcesTest.java
@@ -6,7 +6,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -15,13 +15,13 @@ public class EmptyLabeledResourcesTest {
     private EmptyLabeledResources emptyLabeledResources;
 
     @Before
-    public void setUp() throws IOException, OpenRDFException {
+    public void setUp() throws IOException, RDF4JException {
         emptyLabeledResources = new EmptyLabeledResources();
         emptyLabeledResources.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("emptyLabels.rdf").getConnection());
     }
 
     @Test
-    public void testEmptyLabels() throws OpenRDFException {
+    public void testEmptyLabels() throws RDF4JException {
         EmptyLabelsResult result = emptyLabeledResources.getResult();
         Assert.assertEquals(3, result.occurrenceCount());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/HierarchicalCyclesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/HierarchicalCyclesTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,7 +19,7 @@ public class HierarchicalCyclesTest {
     private HierarchicalCycles hierarchicalCycles, hierarchicalCyclesForComponents;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         hierarchicalCycles = new HierarchicalCycles(new HierarchyGraphBuilder());
         hierarchicalCycles.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("cycles.rdf").getConnection());
 
@@ -28,12 +28,12 @@ public class HierarchicalCyclesTest {
     }
 
     @Test
-    public void testCycleCount() throws OpenRDFException {
+    public void testCycleCount() throws RDF4JException {
         Assert.assertEquals(3, hierarchicalCycles.getResult().getData().size());
     }
 
     @Test
-    public void testComponentsCycleCount() throws OpenRDFException {
+    public void testComponentsCycleCount() throws RDF4JException {
         Assert.assertEquals(3, hierarchicalCyclesForComponents.getResult().getData().size());
     }
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/HierarchicalRedundancyTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/HierarchicalRedundancyTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -14,13 +14,13 @@ public class HierarchicalRedundancyTest {
     private HierarchicalRedundancy hierarchicalRedundancy;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         hierarchicalRedundancy = new HierarchicalRedundancy();
         hierarchicalRedundancy.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("hierarchicalRedundancy.rdf").getConnection());
     }
 
     @Test
-    public void redundancyCount() throws OpenRDFException {
+    public void redundancyCount() throws RDF4JException {
         Assert.assertEquals(5, hierarchicalRedundancy.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/HttpURIsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/HttpURIsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,7 +19,7 @@ public class HttpURIsTest {
     private HttpURIs httpURIs1, httpURIs2;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         httpURIs1 = new HttpURIs();
         httpURIs1.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
 
@@ -28,12 +28,12 @@ public class HttpURIsTest {
     }
 
     @Test
-    public void testConceptsHttpUriCount() throws OpenRDFException {
+    public void testConceptsHttpUriCount() throws RDF4JException {
         Assert.assertEquals(21, httpURIs1.getResult().getData().size());
     }
 
     @Test
-    public void testResourcesHttpUriCount() throws OpenRDFException {
+    public void testResourcesHttpUriCount() throws RDF4JException {
         Assert.assertEquals(8, httpURIs2.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/IncompleteLanguageCoverageTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/IncompleteLanguageCoverageTest.java
@@ -7,9 +7,9 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,13 +22,13 @@ public class IncompleteLanguageCoverageTest {
     private IncompleteLanguageCoverage incompleteLanguageCoverage;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         incompleteLanguageCoverage = new IncompleteLanguageCoverage(new LanguageCoverage(new InvolvedConcepts()));
         incompleteLanguageCoverage.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
     }
 
     @Test
-    public void testIncompleteLanguageCoverageCount() throws OpenRDFException
+    public void testIncompleteLanguageCoverageCount() throws RDF4JException
     {
         Map<Resource, Collection<String>> incompleteLangCoverage = incompleteLanguageCoverage.getResult().getData();
         Assert.assertEquals(13, incompleteLangCoverage.size());
@@ -36,7 +36,7 @@ public class IncompleteLanguageCoverageTest {
 
     @Test
     public void testExistResourcesNotHavingEnglishLabels()
-            throws OpenRDFException
+            throws RDF4JException
     {
         Map<Resource, Collection<String>> incompleteLangCoverage = incompleteLanguageCoverage.getResult().getData();
 
@@ -51,7 +51,7 @@ public class IncompleteLanguageCoverageTest {
 
     @Test
     public void testResourcesMissingOnlyFrenchLabelsCount()
-            throws OpenRDFException
+            throws RDF4JException
     {
         Map<Resource, Collection<String>> incompleteLangCoverage = incompleteLanguageCoverage.getResult().getData();
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/InconsistentPrefLabelsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/InconsistentPrefLabelsTest.java
@@ -8,7 +8,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -18,13 +18,13 @@ public class InconsistentPrefLabelsTest {
     private InconsistentPrefLabels inconsistentPrefLabels;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         inconsistentPrefLabels = new InconsistentPrefLabels(new ResourceLabelsCollector());
         inconsistentPrefLabels.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("ambiguousLabels.rdf").getConnection());
     }
 
     @Test
-    public void testUniquePrefLabels() throws OpenRDFException {
+    public void testUniquePrefLabels() throws RDF4JException {
         Collection<LabelConflict> ambiguousResources = inconsistentPrefLabels.getResult().getData();
 
         Assert.assertTrue(UriSuffixFinder.isPartOfConflict(ambiguousResources, "conceptA"));

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/InvalidCharactersTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/InvalidCharactersTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -13,13 +13,13 @@ public class InvalidCharactersTest {
     private QSkos qSkosInvalidCharacters;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         qSkosInvalidCharacters = new QSkos();
         qSkosInvalidCharacters.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("invalidCharacters.rdf").getConnection());
     }
 
     @Test
-    public void testAllIssues() throws OpenRDFException {
+    public void testAllIssues() throws RDF4JException {
         // all issues must run without exception
         try {
             for (Issue issue : qSkosInvalidCharacters.getAllIssues()) {

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/InvolvedConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/InvolvedConceptsTest.java
@@ -5,8 +5,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -16,7 +16,7 @@ public class InvolvedConceptsTest {
     private InvolvedConcepts involvedConceptsForConcepts, involvedConceptsForComponents;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         involvedConceptsForConcepts = new InvolvedConcepts();
         involvedConceptsForConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
 
@@ -25,14 +25,14 @@ public class InvolvedConceptsTest {
     }
 
     @Test
-    public void testConceptCount_1() throws OpenRDFException
+    public void testConceptCount_1() throws RDF4JException
     {
         Collection<Resource> involvedConceptValues = involvedConceptsForConcepts.getResult().getData();
         Assert.assertEquals(10, involvedConceptValues.size());
     }
 
     @Test
-    public void testConceptCount_2() throws OpenRDFException
+    public void testConceptCount_2() throws RDF4JException
     {
         Collection<Resource> involvedConceptValues = involvedConceptsForComponents.getResult().getData();
         Assert.assertEquals(21, involvedConceptValues.size());

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/LexicalRelationsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/LexicalRelationsTest.java
@@ -6,7 +6,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -20,14 +20,14 @@ public class LexicalRelationsTest {
     private LexicalRelations lexicalRelations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException
+    public void setUp() throws RDF4JException, IOException
     {
         lexicalRelations = new LexicalRelations(new InvolvedConcepts());
         lexicalRelations.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
     }
 
     @Test
-    public void testLexicalRelationsCount() throws OpenRDFException {
+    public void testLexicalRelationsCount() throws RDF4JException {
         Assert.assertEquals(29, lexicalRelations.getResult().getData().longValue());
     }
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/MappingClashesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/MappingClashesTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -14,13 +14,13 @@ public class MappingClashesTest {
     private MappingClashes mappingClashes;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         mappingClashes = new MappingClashes();
         mappingClashes.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("exactVsAssociativeMappingClashes.rdf").getConnection());
     }
 
     @Test
-    public void testExactVsAssociativeMappingClashes() throws OpenRDFException {
+    public void testExactVsAssociativeMappingClashes() throws RDF4JException {
         Assert.assertEquals(5, mappingClashes.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/MappingRelationsMisuseTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/MappingRelationsMisuseTest.java
@@ -7,8 +7,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Statement;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Statement;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -18,7 +18,7 @@ public class MappingRelationsMisuseTest {
     private MappingRelationsMisuse mappingRelationsMisuse;
 
     @Before
-    public void setUp() throws IOException, OpenRDFException
+    public void setUp() throws IOException, RDF4JException
     {
         mappingRelationsMisuse = new MappingRelationsMisuse(new AuthoritativeConcepts(new InvolvedConcepts()));
         mappingRelationsMisuse.setRepositoryConnection(
@@ -26,12 +26,12 @@ public class MappingRelationsMisuseTest {
     }
 
     @Test
-    public void mappingRelationsMisuseCount() throws OpenRDFException {
+    public void mappingRelationsMisuseCount() throws RDF4JException {
         Assert.assertEquals(5, mappingRelationsMisuse.getResult().getData().size());
     }
 
     @Test
-    public void affectedConcepts() throws OpenRDFException {
+    public void affectedConcepts() throws RDF4JException {
         Collection<Statement> result = mappingRelationsMisuse.getResult().getData();
 
         Assert.assertTrue(isAffected("conceptA", "conceptB", result));

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingInLinksTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingInLinksTest.java
@@ -7,8 +7,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -19,7 +19,7 @@ public class MissingInLinksTest {
     private AuthoritativeConcepts authoritativeConcepts;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         authoritativeConcepts = new AuthoritativeConcepts(new InvolvedConcepts());
 
         missingInLinks = new MissingInLinks(authoritativeConcepts);
@@ -28,7 +28,7 @@ public class MissingInLinksTest {
     }
 
     @Test
-    public void testInLinksAsDbPedia() throws OpenRDFException {
+    public void testInLinksAsDbPedia() throws RDF4JException {
         authoritativeConcepts.setAuthResourceIdentifier("dbpedia.org");
 
         Collection<Resource> conceptsMissingInLinks = missingInLinks.getResult().getData();
@@ -36,7 +36,7 @@ public class MissingInLinksTest {
     }
 
     @Test
-    public void testInLinksAsSTW() throws OpenRDFException {
+    public void testInLinksAsSTW() throws RDF4JException {
         authoritativeConcepts.setAuthResourceIdentifier("zbw.eu");
 
         Collection<Resource> conceptsMissingInLinks = missingInLinks.getResult().getData();
@@ -44,7 +44,7 @@ public class MissingInLinksTest {
     }
 
     @Test
-    public void testInLinksAsBnf() throws OpenRDFException {
+    public void testInLinksAsBnf() throws RDF4JException {
         authoritativeConcepts.setAuthResourceIdentifier("data.bnf.fr");
 
         Collection<Resource> conceptsMissingInLinks = missingInLinks.getResult().getData();
@@ -53,7 +53,7 @@ public class MissingInLinksTest {
 
 
     @Test
-    public void testInLinksAsLocal() throws OpenRDFException {
+    public void testInLinksAsLocal() throws RDF4JException {
         authoritativeConcepts.setAuthResourceIdentifier("myvocab.org");
 
         Collection<Resource> conceptsMissingInLinks = missingInLinks.getResult().getData();

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingLabelsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingLabelsTest.java
@@ -8,10 +8,10 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -22,7 +22,7 @@ public class MissingLabelsTest {
     private Collection<Resource> conceptsAndConceptSchemesWithMissingLabels;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         RepositoryConnection repCon = new RepositoryBuilder().setUpFromTestResource("missingLabels.rdf").getConnection();
 
         AuthoritativeConcepts authConcepts = new AuthoritativeConcepts(new InvolvedConcepts());
@@ -32,7 +32,7 @@ public class MissingLabelsTest {
     }
 
     @Test
-    public void checkLabeledConcepts() throws OpenRDFException {
+    public void checkLabeledConcepts() throws RDF4JException {
         conceptsAndConceptSchemesWithMissingLabels = missingLabels.getResult().getData();
 
         Assert.assertTrue(isUnlabeled("conceptA"));
@@ -48,7 +48,7 @@ public class MissingLabelsTest {
     }
 
     @Test
-    public void checkLabeledConceptSchemes() throws OpenRDFException {
+    public void checkLabeledConceptSchemes() throws RDF4JException {
         conceptsAndConceptSchemesWithMissingLabels = missingLabels.getResult().getData();
 
         Assert.assertTrue(isUnlabeled("conceptSchemeC"));
@@ -61,7 +61,7 @@ public class MissingLabelsTest {
     }
 
     @Test
-    public void countMissingLabels() throws OpenRDFException {
+    public void countMissingLabels() throws RDF4JException {
         conceptsAndConceptSchemesWithMissingLabels = missingLabels.getResult().getData();
         Assert.assertEquals(7, conceptsAndConceptSchemesWithMissingLabels.size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingOutLinksTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/MissingOutLinksTest.java
@@ -7,7 +7,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -22,7 +22,7 @@ public class MissingOutLinksTest {
     private MissingOutLinks missingOutLinksForComponents, missingOutLinksForConcepts;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         involvedConceptsForComponents = new InvolvedConcepts();
         missingOutLinksForComponents = new MissingOutLinks(new AuthoritativeConcepts(involvedConceptsForComponents));
         missingOutLinksForComponents.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
@@ -32,13 +32,13 @@ public class MissingOutLinksTest {
     }
 
     @Test
-    public void testComponentsMissingOutLinkCount() throws OpenRDFException {
+    public void testComponentsMissingOutLinkCount() throws RDF4JException {
         Assert.assertEquals(involvedConceptsForComponents.getResult().getData().size(),
                             missingOutLinksForComponents.getResult().getData().size());
     }
 
     @Test
-    public void testConceptsMissingOutLinkCount() throws OpenRDFException {
+    public void testConceptsMissingOutLinkCount() throws RDF4JException {
         Assert.assertEquals(7, missingOutLinksForConcepts.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/NoCommonLanguagesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/NoCommonLanguagesTest.java
@@ -7,7 +7,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -16,18 +16,18 @@ public class NoCommonLanguagesTest {
     private NoCommonLanguages noCommonLanguages;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         noCommonLanguages = new NoCommonLanguages(new LanguageCoverage(new InvolvedConcepts()));
     }
 
     @Test
-    public void oneCommonLang() throws OpenRDFException, IOException {
+    public void oneCommonLang() throws RDF4JException, IOException {
         noCommonLanguages.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("commonlanguage_en.rdf").getConnection());
         Assert.assertEquals(1, noCommonLanguages.getResult().getData().size());
     }
 
     @Test
-    public void noCommonLang() throws OpenRDFException, IOException {
+    public void noCommonLang() throws RDF4JException, IOException {
         noCommonLanguages.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("nocommonlanguage.rdf").getConnection());
         Assert.assertEquals(0, noCommonLanguages.getResult().getData().size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/NonHttpResourcesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/NonHttpResourcesTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,7 +19,7 @@ public class NonHttpResourcesTest {
     private HttpUriSchemeViolations httpUriSchemeViolationsForConcepts, httpResourcesForUriSchemeViolations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         httpUriSchemeViolationsForConcepts = new HttpUriSchemeViolations();
         httpUriSchemeViolationsForConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
 
@@ -29,12 +29,12 @@ public class NonHttpResourcesTest {
 
 
     @Test
-    public void testConceptsNonHttpUriCount() throws OpenRDFException {
+    public void testConceptsNonHttpUriCount() throws RDF4JException {
         Assert.assertEquals(1, httpUriSchemeViolationsForConcepts.getResult().getData().size());
     }
 
     @Test
-    public void testResourcesNonHttpUriCount() throws OpenRDFException {
+    public void testResourcesNonHttpUriCount() throws RDF4JException {
         Assert.assertEquals(4, httpResourcesForUriSchemeViolations.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/OmittedOrInvalidLanguageTagsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/OmittedOrInvalidLanguageTagsTest.java
@@ -5,9 +5,9 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -23,7 +23,7 @@ public class OmittedOrInvalidLanguageTagsTest {
     private OmittedOrInvalidLanguageTags oiltComponents, oiltDeprecatedAndIllegal, oiltLangTags;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         oiltComponents = new OmittedOrInvalidLanguageTags();
         oiltComponents.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
 
@@ -35,12 +35,12 @@ public class OmittedOrInvalidLanguageTagsTest {
     }
 
     @Test
-    public void testMissingLangTagCount_1() throws OpenRDFException {
+    public void testMissingLangTagCount_1() throws RDF4JException {
         Assert.assertEquals(3, oiltComponents.getResult().getData().size());
     }
 
     @Test
-    public void testMissingLangTagCount_2() throws OpenRDFException {
+    public void testMissingLangTagCount_2() throws RDF4JException {
         Map<Resource, Collection<Literal>> missingLangTags = oiltDeprecatedAndIllegal.getResult().getData();
 
         Assert.assertEquals(1, missingLangTags.keySet().size());
@@ -56,7 +56,7 @@ public class OmittedOrInvalidLanguageTagsTest {
     }
 
     @Test
-    public void testMissingLangTagCount_3() throws OpenRDFException {
+    public void testMissingLangTagCount_3() throws RDF4JException {
         Assert.assertEquals(2, oiltLangTags.getResult().getData().size());
     }
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/OmittedTopConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/OmittedTopConceptsTest.java
@@ -6,7 +6,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -16,13 +16,13 @@ public class OmittedTopConceptsTest {
 	private OmittedTopConcepts omittedTopConcepts;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         omittedTopConcepts = new OmittedTopConcepts(new ConceptSchemes());
         omittedTopConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("missingTopConcepts.rdf").getConnection());
 	}
 	
 	@Test
-	public void testConceptSchemesWithoutTopConceptsCount() throws OpenRDFException {
+	public void testConceptSchemesWithoutTopConceptsCount() throws RDF4JException {
 		Assert.assertEquals(2, omittedTopConcepts.getResult().getData().size());
 	}
 	

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/OrphanConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/OrphanConceptsTest.java
@@ -6,8 +6,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -22,7 +22,7 @@ public class OrphanConceptsTest {
     private OrphanConcepts orphanConceptsForConcepts, orphanConceptsForComponents;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         orphanConceptsForConcepts = new OrphanConcepts(new InvolvedConcepts());
         orphanConceptsForConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
 
@@ -31,13 +31,13 @@ public class OrphanConceptsTest {
     }
 
     @Test
-    public void testConceptsLooseConceptCount() throws OpenRDFException {
+    public void testConceptsLooseConceptCount() throws RDF4JException {
         Collection<Resource> orphanConceptValues = orphanConceptsForConcepts.getResult().getData();
         Assert.assertEquals(7, orphanConceptValues.size());
     }
 
     @Test
-    public void testComponentsLooseConceptCount() throws OpenRDFException {
+    public void testComponentsLooseConceptCount() throws RDF4JException {
         Collection<Resource> orphanConceptValues = orphanConceptsForComponents.getResult().getData();
         Assert.assertEquals(2, orphanConceptValues.size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/OverlappingLabelsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/OverlappingLabelsTest.java
@@ -7,8 +7,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Value;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -20,7 +20,7 @@ public class OverlappingLabelsTest {
     private OverlappingLabels overlappingLabelsForComponents, overlappingLabelsForRelatedConcepts, overlappingLabels;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         overlappingLabelsForComponents = new OverlappingLabels(new InvolvedConcepts());
         overlappingLabelsForComponents.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
 
@@ -32,7 +32,7 @@ public class OverlappingLabelsTest {
     }
 
     @Test
-    public void testLabelConflictCount_1() throws OpenRDFException {
+    public void testLabelConflictCount_1() throws RDF4JException {
         Collection<LabelConflict> allLabelConflicts = overlappingLabelsForComponents.getResult().getData();
 
         Assert.assertEquals(2, allLabelConflicts.size());
@@ -40,7 +40,7 @@ public class OverlappingLabelsTest {
     }
 
     @Test
-    public void testCaseInsensitive() throws OpenRDFException {
+    public void testCaseInsensitive() throws RDF4JException {
         Assert.assertEquals(2, overlappingLabels.getResult().getData().size());
     }
 
@@ -56,7 +56,7 @@ public class OverlappingLabelsTest {
     }
 
     @Test
-    public void testLabelConflictCount_2() throws OpenRDFException {
+    public void testLabelConflictCount_2() throws RDF4JException {
         Assert.assertEquals(0, overlappingLabelsForRelatedConcepts.getResult().getData().size());
     }
 }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/ReflexivelyRelatedConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/ReflexivelyRelatedConceptsTest.java
@@ -7,7 +7,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -16,7 +16,7 @@ public class ReflexivelyRelatedConceptsTest {
     private ReflexivelyRelatedConcepts reflexivelyRelatedConcepts;
 
     @Before
-    public void setUp() throws IOException, OpenRDFException
+    public void setUp() throws IOException, RDF4JException
     {
         reflexivelyRelatedConcepts = new ReflexivelyRelatedConcepts(new AuthoritativeConcepts(new InvolvedConcepts()));
         reflexivelyRelatedConcepts.setRepositoryConnection(
@@ -24,7 +24,7 @@ public class ReflexivelyRelatedConceptsTest {
     }
 
     @Test
-    public void mappingRelationsMisuseCount() throws OpenRDFException {
+    public void mappingRelationsMisuseCount() throws RDF4JException {
         Assert.assertEquals(2, reflexivelyRelatedConcepts.getResult().getData().size());
     }
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/RelationClashesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/RelationClashesTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -14,13 +14,13 @@ public class RelationClashesTest {
     private RelationClashes relationClashes;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         relationClashes = new RelationClashes(new HierarchyGraphBuilder());
         relationClashes.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("relationClashes.rdf").getConnection());
     }
 
     @Test
-    public void testAssociativeVsHierarchicalClashes() throws OpenRDFException {
+    public void testAssociativeVsHierarchicalClashes() throws RDF4JException {
         Assert.assertEquals(10, relationClashes.getResult().getData().size());
     }
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/SemanticRelationsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/SemanticRelationsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -19,13 +19,13 @@ public class SemanticRelationsTest {
     private SemanticRelations semanticRelations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         semanticRelations = new SemanticRelations();
         semanticRelations.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("components.rdf").getConnection());
     }
 
     @Test
-    public void testLexicalRelationsCount() throws OpenRDFException
+    public void testLexicalRelationsCount() throws RDF4JException
     {
         Assert.assertEquals(18, semanticRelations.getResult().getData().longValue());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/SkosXlTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/SkosXlTest.java
@@ -10,8 +10,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.repository.Repository;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.repository.Repository;
 
 import java.io.IOException;
 
@@ -23,7 +23,7 @@ public class SkosXlTest {
     private OverlappingLabels overlappingLabels;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         RepositoryBuilder repositoryBuilder = new RepositoryBuilder();
         Repository repo = repositoryBuilder.setUpFromTestResource("skosxl.rdf");
         repositoryBuilder.enableSkosXlSupport();
@@ -42,22 +42,22 @@ public class SkosXlTest {
     }
 	
 	@Test
-	public void lexicalRelationsCountTest() throws OpenRDFException {
+	public void lexicalRelationsCountTest() throws RDF4JException {
 		Assert.assertEquals(5, lexicalRelations.getResult().getData().intValue());
 	}
 	
 	@Test
-	public void omittedLangTagCount() throws OpenRDFException {
+	public void omittedLangTagCount() throws RDF4JException {
 		Assert.assertEquals(2, omittedOrInvalidLanguageTags.getResult().getData().size());
 	}
 	
 	@Test
-	public void incompleteLangCovCount() throws OpenRDFException {
+	public void incompleteLangCovCount() throws RDF4JException {
 		Assert.assertEquals(2, incompleteLanguageCoverage.getResult().getData().size());
 	}
 
 	@Test
-	public void labelConflictCount() throws OpenRDFException {
+	public void labelConflictCount() throws RDF4JException {
 		Assert.assertEquals(1, overlappingLabels.getResult().getData().size());
 	}
 

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/SolelyTransitivelyRelatedConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/SolelyTransitivelyRelatedConceptsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -14,13 +14,13 @@ public class SolelyTransitivelyRelatedConceptsTest {
 	private SolelyTransitivelyRelatedConcepts solelyTransitivelyRelatedConcepts;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         solelyTransitivelyRelatedConcepts = new SolelyTransitivelyRelatedConcepts();
         solelyTransitivelyRelatedConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("solitaryTransitiveRelations.rdf").getConnection());
 	}
 
 	@Test
-	public void testSolitaryTransitiveRelationsCount() throws OpenRDFException {
+	public void testSolitaryTransitiveRelationsCount() throws RDF4JException {
 		Assert.assertEquals(4, solelyTransitivelyRelatedConcepts.getResult().getData().size());
 	}
 	

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/TopConceptsHavingBroaderConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/TopConceptsHavingBroaderConceptsTest.java
@@ -5,7 +5,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 
@@ -15,13 +15,13 @@ public class TopConceptsHavingBroaderConceptsTest {
 	private TopConceptsHavingBroaderConcepts topConceptsHavingBroaderConcepts;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         topConceptsHavingBroaderConcepts = new TopConceptsHavingBroaderConcepts();
         topConceptsHavingBroaderConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("topConceptsHavingBroaderConcept.rdf").getConnection());
 	}
 	
 	@Test
-	public void testTopConceptsHavingBroaderConceptCount() throws OpenRDFException {
+	public void testTopConceptsHavingBroaderConceptCount() throws RDF4JException {
 		Assert.assertEquals(4, topConceptsHavingBroaderConcepts.getResult().getData().size());
 	}
 	

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/UndefinedSkosResourcesTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/UndefinedSkosResourcesTest.java
@@ -5,8 +5,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -17,7 +17,7 @@ public class UndefinedSkosResourcesTest {
 	private UndefinedSkosResources undefinedSkosResourcesInConcepts, undefinedSkosResourcesInDeprecatedAndIllegal;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         undefinedSkosResourcesInConcepts = new UndefinedSkosResources();
         undefinedSkosResourcesInConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("concepts.rdf").getConnection());
         undefinedSkosResourcesInDeprecatedAndIllegal = new UndefinedSkosResources();
@@ -25,13 +25,13 @@ public class UndefinedSkosResourcesTest {
 	}
 	
 	@Test
-	public void testUndefinedSkosResourcesCount_1() throws OpenRDFException {
+	public void testUndefinedSkosResourcesCount_1() throws RDF4JException {
 		Collection<URI> undefRes = undefinedSkosResourcesInConcepts.getResult().getData();
 		Assert.assertEquals(3, undefRes.size());
 	}
 
 	@Test
-	public void testUndefinedSkosResourcesCount_2() throws OpenRDFException {
+	public void testUndefinedSkosResourcesCount_2() throws RDF4JException {
 		Collection<URI> undefRes = undefinedSkosResourcesInDeprecatedAndIllegal.getResult().getData();
 		Assert.assertEquals(12, undefRes.size());
 	}

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/UndocumentedConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/UndocumentedConceptsTest.java
@@ -7,8 +7,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.repository.RepositoryConnection;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 
 import java.io.IOException;
 
@@ -19,14 +19,14 @@ public class UndocumentedConceptsTest {
     private RepositoryConnection repCon;
 	
 	@Before
-	public void setUp() throws OpenRDFException, IOException {
+	public void setUp() throws RDF4JException, IOException {
         repCon = new RepositoryBuilder().setUpFromTestResource("documentedConcepts.rdf").getConnection();
         undocumentedConcepts = new UndocumentedConcepts(new AuthoritativeConcepts(new InvolvedConcepts()));
         undocumentedConcepts.setRepositoryConnection(repCon);
 	}
 	
 	@Test
-	public void testAverageDocumentationCoverageRatio() throws OpenRDFException {
+	public void testAverageDocumentationCoverageRatio() throws RDF4JException {
 		Assert.assertEquals(1, undocumentedConcepts.getResult().getData().size());
 	}
 	

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/UnidirectionallyRelatedConceptsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/UnidirectionallyRelatedConceptsTest.java
@@ -8,8 +8,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.Resource;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.Resource;
 
 import java.io.IOException;
 import java.util.Map;
@@ -19,13 +19,13 @@ public class UnidirectionallyRelatedConceptsTest {
     private UnidirectionallyRelatedConcepts unidirectionallyRelatedConcepts;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         unidirectionallyRelatedConcepts = new UnidirectionallyRelatedConcepts(new AuthoritativeConcepts(new InvolvedConcepts()));
         unidirectionallyRelatedConcepts.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("omittedInverseRelations.rdf").getConnection());
     }
 
     @Test
-    public void testMissingInverseRelationsCount() throws OpenRDFException {
+    public void testMissingInverseRelationsCount() throws RDF4JException {
         Map<Tuple<Resource>, String> missingRelations = unidirectionallyRelatedConcepts.getResult().getData();
         Assert.assertEquals(8, missingRelations.size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/issues/ValuelessAssociativeRelationsTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/issues/ValuelessAssociativeRelationsTest.java
@@ -6,8 +6,8 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
-import org.openrdf.model.URI;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.URI;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -17,13 +17,13 @@ public class ValuelessAssociativeRelationsTest {
     private ValuelessAssociativeRelations valuelessAssociativeRelations;
 
     @Before
-    public void setUp() throws OpenRDFException, IOException {
+    public void setUp() throws RDF4JException, IOException {
         valuelessAssociativeRelations = new ValuelessAssociativeRelations();
         valuelessAssociativeRelations.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("redundantAssociativeRelations.rdf").getConnection());
     }
 
     @Test
-    public void testRedundantAssociativeRelationsCount() throws OpenRDFException {
+    public void testRedundantAssociativeRelationsCount() throws RDF4JException {
         Collection<Tuple<URI>> redAssRels = valuelessAssociativeRelations.getResult().getData();
         Assert.assertEquals(6, redAssRels.size());
     }

--- a/src/test/java/at/ac/univie/mminf/qskos4j/qskos/IssueIdTest.java
+++ b/src/test/java/at/ac/univie/mminf/qskos4j/qskos/IssueIdTest.java
@@ -7,7 +7,7 @@ import at.ac.univie.mminf.qskos4j.util.vocab.RepositoryBuilder;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.OpenRDFException;
+import org.eclipse.rdf4j.RDF4JException;
 
 import java.io.IOException;
 import java.util.*;
@@ -17,7 +17,7 @@ public class IssueIdTest {
     private QSkos qskos;
 
     @Before
-    public void setUp() throws IOException, OpenRDFException
+    public void setUp() throws IOException, RDF4JException
     {
         qskos = new QSkos();
         qskos.setRepositoryConnection(new RepositoryBuilder().setUpFromTestResource("nocontent.rdf").getConnection());


### PR DESCRIPTION
Upgrade to RDF4J 2.2.1
Upgrade some dependencies to avoid clashes between different versions
Upgrade to Java 8
Upgrade Maven Plugin versions
Updated version to 2.0.0

Checked that the unit tests passed, and that the one-jar could be run properly.